### PR TITLE
Improve deserialization compile time

### DIFF
--- a/rmp/src/decode/mod.rs
+++ b/rmp/src/decode/mod.rs
@@ -104,7 +104,10 @@ pub trait RmpRead: sealed::Sealed {
     #[inline]
     #[doc(hidden)]
     fn read_data_u8(&mut self) -> Result<u8, ValueReadError<Self::Error>> {
-        self.read_u8().map_err(ValueReadError::InvalidDataRead)
+        match self.read_u8() {
+            Ok(v) => Ok(v),
+            Err(e) => Err(ValueReadError::InvalidDataRead(e)),
+        }
     }
     /// Read a single (signed) byte from this stream.
     #[inline]


### PR DESCRIPTION
Take as much code out of generic methods that are instantiated for each type (about 300x for PTCL messages). This reduces the LLVM IR lines from 3652241 to 3238664 (-11.3%) and the time to compile `rmp_serde::from_slice::<PTCLMessageVec>(&[])` from 52s to 33s (-36%).

Here are the LLVM stats of the worst offenders:

before
```
  Lines                  Copies               Function name
  -----                  ------               -------------
  3652241                71401                (TOTAL)
   350636 (9.6%,  9.6%)    331 (0.5%,  0.5%)  rmp_serde::decode::Deserializer<R,C>::any_inner
   256153 (7.0%, 16.6%)    339 (0.5%,  0.9%)  rmp_serde::decode::any_num
   253829 (6.9%, 23.6%)    302 (0.4%,  1.4%)  <serde_value::de::ValueDeserializer<E> as serde::de::Deserializer>::deserialize_any
   174191 (4.8%, 28.3%)    935 (1.3%,  2.7%)  serde::de::Visitor::visit_byte_buf
   150146 (4.1%, 32.4%)    263 (0.4%,  3.0%)  <serde_value::de::ValueDeserializer<E> as serde::de::Deserializer>::deserialize_struct
   102226 (2.8%, 35.2%)    399 (0.6%,  3.6%)  <serde_value::de::ValueDeserializer<E> as serde::de::Deserializer>::deserialize_identifier
    69688 (1.9%, 37.2%)   1218 (1.7%,  5.3%)  core::result::Result<T,E>::map_err
    63733 (1.7%, 38.9%)    331 (0.5%,  5.8%)  rmp_serde::decode::read_str_data
    55013 (1.5%, 40.4%)    755 (1.1%,  6.8%)  <serde::de::value::SeqDeserializer<I,E> as serde::de::SeqAccess>::next_element_seed
    34399 (0.9%, 41.3%)    400 (0.6%,  7.4%)  <serde::de::value::MapDeserializer<I,E> as serde::de::MapAccess>::next_key_seed
    30805 (0.8%, 42.2%)    906 (1.3%,  8.7%)  <T as erased_serde::ser::Serialize>::do_erased_serialize
    27173 (0.7%, 42.9%)   1268 (1.8%, 10.4%)  serde::de::Visitor::visit_newtype_struct
```

after

```
  Lines                  Copies               Function name
  -----                  ------               -------------
  3238664                71407                (TOTAL)
   253829 (7.8%,  7.8%)    302 (0.4%,  0.4%)  <serde_value::de::ValueDeserializer<E> as serde::de::Deserializer>::deserialize_any
   175446 (5.4%, 13.3%)    331 (0.5%,  0.9%)  rmp_serde::decode::Deserializer<R,C>::any_inner
   174191 (5.4%, 18.6%)    935 (1.3%,  2.2%)  serde::de::Visitor::visit_byte_buf
   150146 (4.6%, 23.3%)    263 (0.4%,  2.6%)  <serde_value::de::ValueDeserializer<E> as serde::de::Deserializer>::deserialize_struct
   102226 (3.2%, 26.4%)    399 (0.6%,  3.1%)  <serde_value::de::ValueDeserializer<E> as serde::de::Deserializer>::deserialize_identifier
    69558 (2.1%, 28.6%)   1214 (1.7%,  4.8%)  core::result::Result<T,E>::map_err
    55013 (1.7%, 30.3%)    755 (1.1%,  5.9%)  <serde::de::value::SeqDeserializer<I,E> as serde::de::SeqAccess>::next_element_seed
    53908 (1.7%, 31.9%)    339 (0.5%,  6.4%)  rmp_serde::decode::any_num
    34399 (1.1%, 33.0%)    400 (0.6%,  6.9%)  <serde::de::value::MapDeserializer<I,E> as serde::de::MapAccess>::next_key_seed
    32777 (1.0%, 34.0%)    331 (0.5%,  7.4%)  rmp_serde::decode::visit_str_data
    30805 (1.0%, 35.0%)    906 (1.3%,  8.6%)  <T as erased_serde::ser::Serialize>::do_erased_serialize
    27173 (0.8%, 35.8%)   1268 (1.8%, 10.4%)  serde::de::Visitor::visit_newtype_struct
```